### PR TITLE
インターフェース定義追加

### DIFF
--- a/src/vendingmachine/announce/Announce.kt
+++ b/src/vendingmachine/announce/Announce.kt
@@ -1,9 +1,10 @@
 package vendingmachine.announce
 
+import vendingmachine.machine.IAnnounce
 
 
-class Announce {
-    fun say(message:String){
+class Announce: IAnnounce {
+    override fun say(message:String){
         println(message)
     }
 }

--- a/src/vendingmachine/machine/IAnnounce.kt
+++ b/src/vendingmachine/machine/IAnnounce.kt
@@ -1,0 +1,5 @@
+package vendingmachine.machine
+
+interface IAnnounce {
+    fun say(message: String)
+}


### PR DESCRIPTION
AnnounceクラスはPrint(出力)に依存しているため、一旦VendingMachineの外から注入する方が良いです。
